### PR TITLE
Use iptables icmp packet type names instead of values

### DIFF
--- a/other/iptables/ip6tables.rules
+++ b/other/iptables/ip6tables.rules
@@ -15,10 +15,12 @@ COMMIT
 -A INPUT -i lo -m conntrack --ctstate NEW -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 0 -j ACCEPT
--A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 3 -j ACCEPT
--A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 8 -m limit --limit 1/sec -j ACCEPT
--A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 11 -j ACCEPT
+-A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type echo-reply -j ACCEPT
+-A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type destination-unreachable -j ACCEPT
+-A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type echo-request -m limit --limit 1/sec -j ACCEPT
+-A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type time-exceeded -j ACCEPT
+-A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type packet-too-big -j ACCEPT
+-A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type parameter-problem -j ACCEPT
 -A INPUT -s fe80::/10 -j ACCEPT
 -A INPUT -d ff00::/8 -j ACCEPT
 -A INPUT -m rt --rt-type 0 --rt-segsleft 0 -j DROP
@@ -37,7 +39,9 @@ COMMIT
 -A OUTPUT -o lo -m conntrack --ctstate NEW -j ACCEPT
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -m conntrack --ctstate NEW,RELATED,ESTABLISHED -j ACCEPT
--A OUTPUT -p ipv6-icmp -m icmp6 --icmpv6-type 8 -j ACCEPT
+-A OUTPUT -p ipv6-icmp -m icmp6 --icmpv6-type echo-request -j ACCEPT
+-A OUTPUT -p ipv6-icmp -m icmp6 --icmpv6-type packet-too-big -j ACCEPT
+-A OUTPUT -p ipv6-icmp -m icmp6 --icmpv6-type parameter-problem -j ACCEPT
 -A OUTPUT -s fe80::/10 -j ACCEPT
 -A OUTPUT -d ff00::/8 -j ACCEPT
 -A OUTPUT -m rt --rt-type 0 --rt-segsleft 0 -j DROP

--- a/other/iptables/ip6tables.sh
+++ b/other/iptables/ip6tables.sh
@@ -42,12 +42,16 @@ $IP6TABLES -A FORWARD -o ppp0 -j ACCEPT                               # Forward 
 $IP6TABLES -A FORWARD -i ppp0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT    # Allow new/already established point-to-point connections
 
 # Allow certain ICMPv6 packets
-$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type 0 -j ACCEPT   # ICMPv6 Echo Reply inbound
-$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type 3 -j ACCEPT   # ICMPv6 Destination Unreachable inbound
-$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type 8 -m limit --limit 1/sec -j ACCEPT    # ICMPv6 Echo Request inbound
-#$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type 8 -j ACCEPT   # ICMPv6 Echo Request inbound
-$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type 11 -j ACCEPT   # ICMPv6 Time Exceeded inbound
-$IP6TABLES -A OUTPUT -p icmpv6 -m icmpv6 --icmpv6-type 8 -j ACCEPT   # ICMPv6 Echo Request outbound
+$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type echo-reply -j ACCEPT   # ICMPv6 Echo Reply inbound
+$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type destination-unreachable -j ACCEPT   # ICMPv6 Destination Unreachable inbound
+$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type echo-request -m limit --limit 1/sec -j ACCEPT    # ICMPv6 Echo Request inbound
+#$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type echo-request -j ACCEPT   # ICMPv6 Echo Request inbound
+$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type time-exceeded -j ACCEPT   # ICMPv6 Time Exceeded inbound
+$IP6TABLES -A OUTPUT -p icmpv6 -m icmpv6 --icmpv6-type echo-request -j ACCEPT   # ICMPv6 Echo Request outbound
+$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type packet-too-big -j ACCEPT  # ICMPv6 Packet too big inbound
+$IP6TABLES -A OUTPUT -p icmpv6 -m icmpv6 --icmpv6-type packet-too-big -j ACCEPT # ICMPv6 Packet too big outbound
+$IP6TABLES -A INPUT -p icmpv6 -m icmpv6 --icmpv6-type parameter-problem -j ACCEPT   # ICMPv6 Parameter problem inbound
+$IP6TABLES -A OUTPUT -p icmpv6 -m icmpv6 --icmpv6-type parameter-problem -j ACCEPT  # ICMPv6 Parameter problem outbound
 
 # Allow Link-Local addresses
 $IP6TABLES -A INPUT -s fe80::/10 -j ACCEPT

--- a/other/iptables/iptables.rules
+++ b/other/iptables/iptables.rules
@@ -55,12 +55,14 @@
 -A FORWARD -i ppp0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -o ppp0 -j ACCEPT
 
--A INPUT -p icmp -m icmp --icmp-type 0 -j ACCEPT
--A INPUT -p icmp -m icmp --icmp-type 3 -j ACCEPT
--A INPUT -p icmp -m icmp --icmp-type 8 -m limit --limit 1/sec -j ACCEPT
-#-A INPUT -p icmp -m icmp --icmp-type 8 -j DROP
--A INPUT -p icmp -m icmp --icmp-type 11 -j ACCEPT
--A OUTPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT
+-A INPUT -p icmp -m icmp --icmp-type echo-reply -j ACCEPT
+-A INPUT -p icmp -m icmp --icmp-type destination-unreachable -j ACCEPT
+-A INPUT -p icmp -m icmp --icmp-type echo-request -m limit --limit 1/sec -j ACCEPT
+-A INPUT -p icmp -m icmp --icmp-type time-exceeded -j ACCEPT
+-A INPUT -p icmp -m icmp --icmp-type parameter-problem -j ACCEPT
+#-A INPUT -p icmp -m icmp --icmp-type echo-request -j DROP
+-A OUTPUT -p icmp -m icmp --icmp-type echo-request -j ACCEPT
+-A OUTPUT -p icmp -m icmp --icmp-type parameter-problem -j ACCEPT
 
 -A INPUT -p tcp -j tcpfilter
 -A tcpfilter -p tcp -m tcp ! --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j DROP

--- a/other/iptables/iptables.sh
+++ b/other/iptables/iptables.sh
@@ -63,12 +63,14 @@ $IPTABLES -A FORWARD -o ppp0 -j ACCEPT                               # Forward p
 $IPTABLES -A FORWARD -i ppp0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT    # Allow new/already established point-to-point connections
 
 # Allow certain ICMP packets
-$IPTABLES -A INPUT -p icmp -m icmp --icmp-type 0 -j ACCEPT   # ICMP Echo Reply inbound
-$IPTABLES -A INPUT -p icmp -m icmp --icmp-type 3 -j ACCEPT   # ICMP Destination Unreachable inbound
-$IPTABLES -A INPUT -p icmp -m icmp --icmp-type 8 -m limit --limit 1/sec -j ACCEPT    # ICMP Echo Request inbound
-#$IPTABLES -A INPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT   # ICMP Echo Request inbound
-$IPTABLES -A INPUT -p icmp -m icmp --icmp-type 11 -j ACCEPT   # ICMP Time Exceeded inbound
-$IPTABLES -A OUTPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT   # ICMP Echo Request outbound
+$IPTABLES -A INPUT -p icmp -m icmp --icmp-type echo-reply -j ACCEPT   # ICMP Echo Reply inbound
+$IPTABLES -A INPUT -p icmp -m icmp --icmp-type destination-unreachable -j ACCEPT   # ICMP Destination Unreachable inbound
+$IPTABLES -A INPUT -p icmp -m icmp --icmp-type echo-request -m limit --limit 1/sec -j ACCEPT    # ICMP Echo Request inbound
+#$IPTABLES -A INPUT -p icmp -m icmp --icmp-type echo-request -j ACCEPT   # ICMP Echo Request inbound
+$IPTABLES -A INPUT -p icmp -m icmp --icmp-type time-exceeded -j ACCEPT   # ICMP Time Exceeded inbound
+$IPTABLES -A OUTPUT -p icmp -m icmp --icmp-type echo-request -j ACCEPT   # ICMP Echo Request outbound
+$IPTABLES -A INPUT -p icmp -m icmp --icmp-type parameter-problem -j ACCEPT   # ICMP Parameter problem inbound
+$IPTABLES -A OUTPUT -p icmp -m icmp --icmp-type parameter-problem -j ACCEPT  # ICMP Parameter problem outbound
 
 # TCP Filter
 $IPTABLES -N tcpfilter


### PR DESCRIPTION
Resolves #3 

Use iptables icmp packet type names instead of values 

refs:
* https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml
* https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml
* https://resources.sei.cmu.edu/tools/downloads/vulnerability-analysis/assets/IPv6/ip6tables_rules.txt
* https://lists.netfilter.org/pipermail/netfilter-buglog/2014-May/003171.html